### PR TITLE
fixes #5 (drop ruby 1.8 support)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ rvm:
   - ruby-head
   - 2.0.0
   - 1.9.3
-  - 1.8.7
   - jruby-head
   - jruby-19mode
-  - jruby-18mode
 


### PR DESCRIPTION
...ourgage people to use ruby 1.9 or 2.0 - both on Heroku and locally.
