### PR TITLE
Allow deploying from a detached head

### DIFF
--- a/lib/heroku-headless/deployer.rb
+++ b/lib/heroku-headless/deployer.rb
@@ -97,7 +97,7 @@ module HerokuHeadless
     def git_push_command
       cmd = "git push "
       cmd << "-f " if HerokuHeadless.configuration.force_push
-      cmd << "git@heroku.com:#{@app_name}.git HEAD:master"
+      cmd << "git@heroku.com:#{@app_name}.git HEAD:refs/heads/master"
     end
 
     def run_pre_deploy_git_commands

--- a/spec/deploy_spec.rb
+++ b/spec/deploy_spec.rb
@@ -58,7 +58,7 @@ describe 'HerokuHeadless' do
           config.force_push = true
         end
       end
-      it {should eq "git push -f git@heroku.com:forced_app.git HEAD:master"}
+      it {should eq "git push -f git@heroku.com:forced_app.git HEAD:refs/heads/master"}
     end
 
     context "disabled forced push" do
@@ -67,7 +67,7 @@ describe 'HerokuHeadless' do
           config.force_push = false
         end
       end
-      it {should eq "git push git@heroku.com:forced_app.git HEAD:master"}
+      it {should eq "git push git@heroku.com:forced_app.git HEAD:refs/heads/master"}
     end
   end
 


### PR DESCRIPTION
I'm having an issue deploying to brand new heroku servers.
The first push to a new server is failing with:

```
error: unable to push to unqualified destination: master
The destination refspec neither matches an existing ref on the remote nor
begins with refs/, and we are unable to guess a prefix based on the source ref.
error: failed to push some refs to 'git@heroku.com:blue-register-18.git'
```

This is important to me as I'm having travis-ci create a new heroku server against each pull request.
Seems to be the same issue discussed here: http://git.661346.n2.nabble.com/error-with-git-push-origin-HEAD-newbranch-td6333596.html
As far as I can tell, the "master" branch is not yet a known branch on the new heroku server, and the local HEAD is detached so git doesn't know whether the "master" it's pushing is a branch or tag. This is resolved by specifying that it is, indeed, a branch: refs/heads/master.
This may be git-version dependent, as mentioned in the mailing list. I experience the error through travis-ci but have been unable to reproduce the error locally locally (git version 1.7.5.4).

Thanks!
